### PR TITLE
added support for fluent interface pattern

### DIFF
--- a/src/base/controller.js
+++ b/src/base/controller.js
@@ -23,10 +23,12 @@ export default class Controller {
    */
   push() {
     this.scope.push.apply(this.scope, arguments);
+    return this;
   }
 
   commit() {
     this.scope.commit.apply(this.scope, arguments);
+    return this;
   }
 
   get() {


### PR DESCRIPTION
Added support for fluent interface pattern for controller.push() and controller.commit() methods.

It makes possible to write like this:
``` javascript
this
.push('one', 'one')
.push('two', 'two');
```

instead of
``` javascript
this.push('one', 'one');
this.push('two', 'two');
```