### PR TITLE
[fix] pushAndApply - fixed bug with arguments, added safeApply

### DIFF
--- a/src/base/controller.js
+++ b/src/base/controller.js
@@ -25,6 +25,10 @@ export default class Controller {
     this.scope.push.apply(this.scope, arguments);
   }
 
+  pushAndApply() {
+    this.scope.pushAndApply.apply(this.scope, arguments);
+  }
+
   commit() {
     this.scope.commit.apply(this.scope, arguments);
   }

--- a/src/wrappers/scope/scope.js
+++ b/src/wrappers/scope/scope.js
@@ -104,9 +104,22 @@ export default class Scope {
     this.clearScopeState();
   }
 
-  pushAndApply() {
+  safeApply(fn) {
     var scope = this[scopeKey];
-    scope.$apply(() => this.push(arguments));
+
+    var phase = scope.$root.$$phase;
+    if(phase == '$apply' || phase == '$digest') {
+      if(fn && (typeof(fn) === 'function')) {
+        fn();
+      }
+    } else {
+      scope.$apply(fn);
+    }
+  };
+
+  pushAndApply(...args) {
+    var scope = this[scopeKey];
+    this.safeApply(() => this.push(...args));
   }
 }
 


### PR DESCRIPTION
1) There was a bug in `pushAndApply`. It never worked.
2) `safeApply` is added in order to handle situations when the scope is already in `$apply` or `$digest` phase